### PR TITLE
Adds single touch event listener

### DIFF
--- a/DeliveryBot/app/src/main/java/com/kimchi/deliverybot/ui/UiMapFragment.kt
+++ b/DeliveryBot/app/src/main/java/com/kimchi/deliverybot/ui/UiMapFragment.kt
@@ -121,7 +121,7 @@ class UiMapFragment: Fragment() {
                         override fun onFinish() {
                             if (!shouldKillTimer) {
                                 Log.e("Arilow", "Timer finished after 300ms")
-                                onSingleTounchEvent()
+                                onSingleTouchEvent()
                             } else {
                                 Log.e("Arilow", "Timer was flagged to be killed, not executing action")
                             }
@@ -130,8 +130,8 @@ class UiMapFragment: Fragment() {
                 }
 
             }
-            fun onSingleTounchEvent() {
-                Log.e("Arilow", "onSingleTounchEvent")
+            fun onSingleTouchEvent() {
+                Log.e("Arilow", "onSingleTouchEvent")
             }
         })
 


### PR DESCRIPTION
Adds a listener to the map view to detect single-touch events.

There are 4 ways of interacting with the map image from the UI:
1- Zoom using 2 fingers
2- Swiping with a finger to move the zoomed map
3- Double tap for a quick zoom
4- Tap once to establish a Goal location

This PR adds the implementation to detect the single-touch event of the 4th item. Unfortunately, the only way I found to detect a single touch event is as a touch that is neither of the other touches.